### PR TITLE
Fix SQL migration: remove non-existent sequence grant

### DIFF
--- a/supabase/migrations/20250101000000_create_user_metrics.sql
+++ b/supabase/migrations/20250101000000_create_user_metrics.sql
@@ -74,7 +74,6 @@ CREATE TRIGGER set_updated_at
 
 -- Grant permissions to authenticated users
 GRANT SELECT, INSERT, UPDATE, DELETE ON public.user_metrics TO authenticated;
-GRANT USAGE ON SEQUENCE user_metrics_id_seq TO authenticated;
 
 -- Add comments for documentation
 COMMENT ON TABLE public.user_metrics IS 'Stores user metrics with categories and values (1-5 scale)';


### PR DESCRIPTION
Remove GRANT USAGE ON SEQUENCE statement that caused error since user_metrics table uses UUID primary key (not SERIAL), so no sequence exists.

Fixes error: relation "user_metrics_id_seq" does not exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)