### PR TITLE
Force rebuild: Add ESLint compliance comment to metrics-table

### DIFF
--- a/components/metrics/metrics-table.tsx
+++ b/components/metrics/metrics-table.tsx
@@ -1,6 +1,7 @@
 /**
  * MetricsTable Component
  * Displays user metrics in a responsive table
+ * Note: All apostrophes properly escaped for ESLint compliance
  */
 
 import { Badge } from "@/components/ui/badge";


### PR DESCRIPTION
Add documentation comment to force Vercel cache invalidation. The apostrophe fix was already present but Vercel may have cached the old build. This change forces a fresh build with clean cache.

Technical note: The &apos; entity is already correctly used on line 35.

🤖 Generated with [Claude Code](https://claude.com/claude-code)