### PR TITLE
feat: agregar asistente de chat con IA (Layout Option C)

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -1,0 +1,79 @@
+import { NextRequest, NextResponse } from "next/server";
+
+const LM_STUDIO_URL = "http://localhost:1234/v1/chat/completions";
+
+const SYSTEM_PROMPT = `Eres un asistente de calibración de desempeño para managers de Falabella.
+Tu rol es ayudar a los managers a:
+- Consultar evaluaciones de su equipo
+- Identificar alertas y casos especiales
+- Comparar desempeño entre colaboradores y años
+- Preparar reuniones de calibración
+
+Datos del equipo 2024:
+
+| Nombre | Potencial | Etiqueta | Jefe Directo | Competencias |
+|--------|-----------|----------|--------------|--------------|
+| Anibal Retamal | 2.5 | Medio (Calibrado) | 2.88 Cumple Parcial | 2.88 |
+| Alvaro Marquez | 2.4 | Bajo (Calibrado) | 3.13 Cumple Satisfactorio | 3.38 Sobresaliente |
+| Paula Roa | 2.5 | Medio (Calibrado) | 3.75 Sobresaliente | 3.75 Sobresaliente |
+| Angeles Zuñiga | 3.0 | Medio + | 3.38 Sobresaliente | 3.14 Cumple Satisfactorio |
+
+Competencias detalladas:
+- Anibal: Somos un solo equipo: 3.0 | Nos movemos ágilmente: 3.0 | Nos apasionamos por cliente: 2.5 | Cuidamos futuro: 3.0
+- Alvaro: Somos un solo equipo: 3.33 | Nos movemos ágilmente: 3.33 | Nos apasionamos por cliente: 3.5 | Cuidamos futuro: 3.33
+- Paula: Somos un solo equipo: 4.0 | Nos movemos ágilmente: 3.5 | Nos apasionamos por cliente: 3.5 | Cuidamos futuro: 4.0
+- Angeles: Somos un solo equipo: 3.25 | Nos movemos ágilmente: 3.19 | Nos apasionamos por cliente: 3.19 | Cuidamos futuro: 2.94
+
+Alertas:
+- Alvaro Marquez: Potencial Bajo (2.4), requiere plan de desarrollo
+- Anibal Retamal: "Nos apasionamos por cliente" bajo (2.5)
+
+Resumen:
+- Total: 4 colaboradores
+- Promedio potencial: 2.6
+- Mejor evaluado: Paula Roa (competencias 3.75)
+- Requiere atención: Alvaro Marquez (potencial bajo)
+
+Responde en español, de forma concisa y profesional. Usa tablas markdown cuando sea útil.`;
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const { messages } = body;
+
+    const response = await fetch(LM_STUDIO_URL, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        model: "local-model",
+        messages: [{ role: "system", content: SYSTEM_PROMPT }, ...messages],
+        temperature: 0.7,
+        max_tokens: 1000,
+        stream: false,
+      }),
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      console.error("LM Studio error:", errorText);
+      return NextResponse.json(
+        { error: "LM Studio error", details: errorText },
+        { status: response.status },
+      );
+    }
+
+    const data = await response.json();
+    const content =
+      data.choices?.[0]?.message?.content || "No pude generar una respuesta.";
+
+    return NextResponse.json({ content });
+  } catch (error) {
+    console.error("API error:", error);
+    return NextResponse.json(
+      { error: "Failed to connect to LM Studio. Is it running?" },
+      { status: 500 },
+    );
+  }
+}

--- a/app/protected/chat/page.tsx
+++ b/app/protected/chat/page.tsx
@@ -1,0 +1,178 @@
+"use client";
+
+/**
+ * Chat-First Calibration Assistant (Option C)
+ * Main interface: Chat with AI + Context sidebar
+ * Prototype for user testing
+ */
+
+import { useState, useEffect, useCallback } from "react";
+import { LayoutDashboard, MessageSquare } from "lucide-react";
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+import { ChatPanel } from "@/components/chat/chat-panel";
+import { ContextSidebar } from "@/components/chat/context-sidebar";
+import {
+  getCurrentManager,
+  getTeamMembers,
+  calculateTeamSummary,
+} from "@/lib/services/performance.client.service";
+import type {
+  Employee,
+  EmployeeWithEvaluation,
+  TeamSummary,
+} from "@/lib/types/performance.types";
+
+export default function ChatPage() {
+  const [manager, setManager] = useState<Employee | null>(null);
+  const [selectedYear] = useState<number>(2024);
+  const [teamMembers, setTeamMembers] = useState<EmployeeWithEvaluation[]>([]);
+  const [teamSummary, setTeamSummary] = useState<TeamSummary>({
+    totalDirectReports: 0,
+    averagePotential: 0,
+    averageCompetencies: 0,
+    highPerformers: 0,
+  });
+  const [isLoading, setIsLoading] = useState(true);
+  const [selectedEmployees, setSelectedEmployees] = useState<string[]>([]);
+
+  // Shared employee selection logic
+  const handleEmployeeSelect = useCallback((employeeKey: string) => {
+    setSelectedEmployees((prev) => {
+      if (prev.includes(employeeKey)) {
+        return prev.filter((k) => k !== employeeKey);
+      }
+      return [...prev, employeeKey];
+    });
+  }, []);
+
+  const handleCloseDetail = useCallback(() => {
+    setSelectedEmployees([]);
+  }, []);
+
+  const handleRemoveFromDetail = useCallback((index: number) => {
+    setSelectedEmployees((prev) => prev.filter((_, i) => i !== index));
+  }, []);
+
+  useEffect(() => {
+    async function loadData() {
+      setIsLoading(true);
+      try {
+        const managerData = await getCurrentManager();
+        setManager(managerData);
+
+        const members = await getTeamMembers(selectedYear);
+        setTeamMembers(members);
+
+        const summary = calculateTeamSummary(members);
+        setTeamSummary(summary);
+      } catch (error) {
+        console.error("Error loading data:", error);
+        // Use mock data for prototype
+        setTeamSummary({
+          totalDirectReports: 8,
+          averagePotential: 3.6,
+          averageCompetencies: 3.8,
+          highPerformers: 4,
+        });
+      } finally {
+        setIsLoading(false);
+      }
+    }
+
+    loadData();
+  }, [selectedYear]);
+
+  // Map sidebar employee names to EMPLOYEES_DATA keys
+  const mapNameToKey = (name: string): string | null => {
+    const lower = name.toLowerCase();
+    if (lower.includes("paula")) return "paula";
+    if (lower.includes("alvaro")) return "alvaro";
+    if (lower.includes("anibal")) return "anibal";
+    if (lower.includes("angeles")) return "angeles";
+    return null;
+  };
+
+  const handleSidebarEmployeeClick = (employeeName: string) => {
+    const key = mapNameToKey(employeeName);
+    if (key) {
+      handleEmployeeSelect(key);
+    }
+  };
+
+  if (isLoading) {
+    return (
+      <div className="flex-1 w-full flex items-center justify-center">
+        <div className="text-center">
+          <div className="h-16 w-16 rounded-2xl bg-gradient-to-br from-primary to-primary/70 flex items-center justify-center shadow-xl shadow-primary/30 mx-auto mb-4 animate-pulse">
+            <MessageSquare className="h-8 w-8 text-primary-foreground" />
+          </div>
+          <p className="text-muted-foreground">
+            Preparando tu mesa de calibración...
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex-1 w-full flex flex-col h-[calc(100vh-4rem)]">
+      {/* Header */}
+      <div className="flex items-center justify-between px-4 py-3 border-b bg-gradient-to-r from-background via-background to-primary/5">
+        <div className="flex items-center gap-3">
+          <div className="h-9 w-9 rounded-lg bg-gradient-to-br from-primary to-primary/70 flex items-center justify-center shadow-lg shadow-primary/20">
+            <MessageSquare className="h-5 w-5 text-primary-foreground" />
+          </div>
+          <div>
+            <h1 className="font-semibold">Mesa de Calibración</h1>
+            <p className="text-xs text-muted-foreground">
+              Preparación inteligente
+            </p>
+          </div>
+        </div>
+        <Link href="/protected">
+          <Button variant="outline" size="sm" className="gap-2">
+            <LayoutDashboard className="h-4 w-4" />
+            Ver Dashboard
+          </Button>
+        </Link>
+      </div>
+
+      {/* Main Content - Option C Layout */}
+      <div className="flex-1 flex overflow-hidden">
+        {/* Context Sidebar (30%) */}
+        <div className="w-80 border-r bg-muted/30 flex-shrink-0 hidden md:block">
+          <ContextSidebar
+            managerName={
+              manager
+                ? `${manager.first_name} ${manager.last_name}`
+                : "Demo Manager"
+            }
+            selectedYear={selectedYear}
+            teamSummary={teamSummary}
+            teamMembers={teamMembers}
+            onEmployeeClick={handleSidebarEmployeeClick}
+            selectedEmployees={selectedEmployees}
+          />
+        </div>
+
+        {/* Chat Panel (70%) */}
+        <div className="flex-1 flex flex-col bg-background overflow-hidden">
+          <ChatPanel
+            contextData={{
+              managerName: manager
+                ? `${manager.first_name} ${manager.last_name}`
+                : "Demo Manager",
+              teamSize: teamSummary.totalDirectReports,
+              selectedYear: selectedYear,
+            }}
+            selectedEmployees={selectedEmployees}
+            onEmployeeSelect={handleEmployeeSelect}
+            onCloseDetail={handleCloseDetail}
+            onRemoveFromDetail={handleRemoveFromDetail}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/protected/page.tsx
+++ b/app/protected/page.tsx
@@ -7,7 +7,9 @@
  */
 
 import { useState, useEffect } from "react";
-import { Users } from "lucide-react";
+import { Users, MessageSquare } from "lucide-react";
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
 import { SummaryCards } from "@/components/dashboard/summary-cards";
 import { TeamTable } from "@/components/dashboard/team-table";
 import { EmployeeDetailModal } from "@/components/dashboard/employee-detail-modal";
@@ -23,9 +25,15 @@ import {
   getEmployeeDetail,
   getAvailableYears,
   getManagerAndTeam,
-  getEmployeeHistoricData
+  getEmployeeHistoricData,
 } from "@/lib/services/performance.client.service";
-import type { Employee, EmployeeWithEvaluation, TeamSummary, EmployeeDetail, HistoricEvaluationData } from "@/lib/types/performance.types";
+import type {
+  Employee,
+  EmployeeWithEvaluation,
+  TeamSummary,
+  EmployeeDetail,
+  HistoricEvaluationData,
+} from "@/lib/types/performance.types";
 
 export default function DashboardPage() {
   // View state
@@ -40,16 +48,21 @@ export default function DashboardPage() {
     totalDirectReports: 0,
     averagePotential: 0,
     averageCompetencies: 0,
-    highPerformers: 0
+    highPerformers: 0,
   });
-  const [employeeDetail, setEmployeeDetail] = useState<EmployeeDetail | null>(null);
+  const [employeeDetail, setEmployeeDetail] = useState<EmployeeDetail | null>(
+    null,
+  );
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
 
   // Individual view state
   const [allEmployees, setAllEmployees] = useState<Employee[]>([]);
-  const [selectedEmployeeId, setSelectedEmployeeId] = useState<string | null>(null);
-  const [historicData, setHistoricData] = useState<HistoricEvaluationData | null>(null);
+  const [selectedEmployeeId, setSelectedEmployeeId] = useState<string | null>(
+    null,
+  );
+  const [historicData, setHistoricData] =
+    useState<HistoricEvaluationData | null>(null);
   const [isLoadingHistoric, setIsLoadingHistoric] = useState(false);
 
   // Load initial data for team view
@@ -166,12 +179,23 @@ export default function DashboardPage() {
                 {currentView === "team" ? "Mi Equipo" : "Vista Individual"}
               </h1>
               <p className="text-sm text-muted-foreground">
-                {manager ? `${manager.first_name} ${manager.last_name}` : 'Cargando...'}
+                {manager
+                  ? `${manager.first_name} ${manager.last_name}`
+                  : "Cargando..."}
               </p>
             </div>
           </div>
           <div className="flex items-center gap-4">
-            <ViewToggle currentView={currentView} onViewChange={handleViewChange} />
+            <Link href="/protected/chat">
+              <Button className="gap-2 bg-gradient-to-r from-primary to-primary/80">
+                <MessageSquare className="h-4 w-4" />
+                Asistente IA
+              </Button>
+            </Link>
+            <ViewToggle
+              currentView={currentView}
+              onViewChange={handleViewChange}
+            />
             {currentView === "team" && (
               <YearSelector
                 selectedYear={selectedYear}
@@ -195,7 +219,10 @@ export default function DashboardPage() {
           {/* Team Table */}
           <div>
             <h2 className="text-xl font-semibold mb-4">Miembros del Equipo</h2>
-            <TeamTable teamMembers={teamMembers} onViewDetails={handleViewDetails} />
+            <TeamTable
+              teamMembers={teamMembers}
+              onViewDetails={handleViewDetails}
+            />
           </div>
         </>
       )}
@@ -216,7 +243,9 @@ export default function DashboardPage() {
             <div className="flex items-center justify-center p-12">
               <div className="text-center">
                 <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-primary mx-auto mb-4"></div>
-                <p className="text-muted-foreground">Cargando datos históricos...</p>
+                <p className="text-muted-foreground">
+                  Cargando datos históricos...
+                </p>
               </div>
             </div>
           )}
@@ -238,13 +267,17 @@ export default function DashboardPage() {
 
           {!isLoadingHistoric && !historicData && selectedEmployeeId && (
             <div className="border rounded-lg p-12 text-center">
-              <p className="text-muted-foreground">No se encontraron datos para este colaborador.</p>
+              <p className="text-muted-foreground">
+                No se encontraron datos para este colaborador.
+              </p>
             </div>
           )}
 
           {!selectedEmployeeId && (
             <div className="border rounded-lg p-12 text-center">
-              <p className="text-muted-foreground">Seleccione un colaborador para ver su historial de evaluaciones.</p>
+              <p className="text-muted-foreground">
+                Seleccione un colaborador para ver su historial de evaluaciones.
+              </p>
             </div>
           )}
         </div>

--- a/components/chat/README.md
+++ b/components/chat/README.md
@@ -1,0 +1,217 @@
+# Chat de Calibración - MVP
+
+Asistente de chat con IA para ayudar a managers en la preparación y ejecución de mesas de calibración de desempeño.
+
+---
+
+## Concepto
+
+El manager interactúa con un **agente de chat** que puede:
+- Consultar datos de su equipo
+- Mostrar **cards de empleados** directamente en el chat
+- Comparar múltiples colaboradores
+- Agregar comentarios a evaluaciones
+
+La interfaz tiene 3 zonas:
+```
+┌─────────────────────────────────────────────────────┐
+│  Sidebar (30%)  │  Chat (40%)  │  Mesa de Trabajo   │
+│                 │              │      (30%)         │
+│  - Contexto     │  - Mensajes  │  - Cards en        │
+│  - Alertas      │  - Cards     │    detalle         │
+│  - Top performers│  inline     │  - Comparaciones   │
+└─────────────────────────────────────────────────────┘
+```
+
+---
+
+## Archivos Actuales
+
+| Archivo | Descripción |
+|---------|-------------|
+| `chat-panel.tsx` | Panel principal del chat con mensajes y cards inline |
+| `context-sidebar.tsx` | Sidebar izquierdo con contexto del equipo |
+| `employee-card.tsx` | Card de empleado individual + `ComparisonCard` para comparaciones |
+| `employee-detail-panel.tsx` | Panel de detalle expandido |
+| `../app/api/chat/route.ts` | API proxy para LM Studio |
+| `../app/protected/chat/page.tsx` | Página principal (layout Option C) |
+
+---
+
+## Cómo Correr
+
+### Sin LM Studio (respuestas mock)
+```bash
+npm run dev
+# Ir a http://localhost:3000/protected/chat
+# El chat responde con datos mock de los 4 empleados
+```
+
+### Con LM Studio (LLM real)
+1. Descargar [LM Studio](https://lmstudio.ai)
+2. Instalar modelo: `Llama 3 8B Instruct`
+3. Iniciar servidor local en puerto `1234`
+4. El chat usará el LLM para respuestas inteligentes
+
+---
+
+## Cards
+
+Las cards muestran información de empleados y pueden aparecer:
+- **Inline en el chat**: Cuando el usuario pregunta por alguien
+- **En la mesa de trabajo**: Para comparación detallada
+
+### Tipos de Cards
+
+| Card | Uso |
+|------|-----|
+| `EmployeeCard` | Vista individual de un empleado (potencial, competencias, alertas) |
+| `ComparisonCard` | Tabla comparativa de 2-4 empleados |
+
+### Datos Mock
+
+4 empleados sincronizados con Supabase seed:
+- Paula Roa (3.75 competencias, mejor evaluada)
+- Angeles Zuñiga (3.0 potencial, Medio+)
+- Anibal Retamal (2.5 potencial, alerta cliente bajo)
+- Alvaro Marquez (2.4 potencial bajo, requiere plan desarrollo)
+
+---
+
+## Features Clave para Demo
+
+Estas son las consultas que el manager debe poder hacer en el demo:
+
+### 1. Fuente Evaluadora
+**Pregunta**: "¿Cómo evaluaron a Angeles y quién la evaluó?"
+
+**Respuesta esperada**:
+```
+Angeles Zuñiga fue evaluada por:
+- Jefe Directo: 3.38 (Sobresaliente)
+- Colaboradores: 3.14 (promedio)
+- Autoevaluación: X.XX
+
+Desglose por evaluador:
+| Evaluador | Relación | Nota |
+|-----------|----------|------|
+| María López | Jefe Directo | 3.38 |
+| Juan Pérez | Par | 3.20 |
+| ... | ... | ... |
+```
+
+### 2. Histórico de Evaluaciones
+**Pregunta**: "¿Hubo cambios en las evaluaciones de Angeles respecto al año pasado?"
+
+**Respuesta esperada**:
+```
+Evolución de Angeles Zuñiga:
+
+| Año | Potencial | Competencias | Cambio |
+|-----|-----------|--------------|--------|
+| 2023 | 2.8 | 3.00 | - |
+| 2024 | 3.0 | 3.14 | ↑ +0.2 / +0.14 |
+
+Nota: Mejoró en potencial, mantiene competencias estables.
+```
+
+### 3. Comparar Personas
+**Pregunta**: "Compara a Paula con Alvaro"
+
+**Respuesta esperada**: ComparisonCard con ambos + análisis textual de diferencias.
+
+### 4. Comentarios
+**Pregunta**: "¿Qué comentarios tiene Anibal?" / "Agrega comentario a Paula"
+
+**Respuesta esperada**: Mostrar comentarios existentes o confirmar nuevo comentario guardado.
+
+---
+
+## Pendiente por Implementar
+
+### 1. Layout de 3 zonas
+**Estado**: No implementado
+
+Reorganizar visualmente:
+- **Sidebar** (izquierda): Contexto, alertas, accesos rápidos
+- **Chat** (centro): Conversación con cards inline
+- **Mesa de trabajo** (derecha): Cards en detalle para comparación
+
+### 2. Cards arbitrarias en el chat
+**Estado**: No implementado
+
+- El chat puede mostrar N cards simultáneas (1, 2, 5, 10...)
+- Las cards se ajustan en tamaño según cantidad
+- Clic en una card → se mueve a la mesa de trabajo
+
+### 3. Mesa de trabajo con contexto
+**Estado**: No implementado
+
+- Zona visual para tener múltiples cards abiertas
+- El usuario puede escribir: "compara las 4 cards que tengo en la mesa"
+- El chat entiende el contexto de lo que está visible
+- **Importante**: La mesa es solo visualización. No mantiene tracking interno. Todo lo relevante va en el texto del chat.
+
+### 4. Guardar conversaciones
+**Estado**: No implementado
+
+- Persistir historial de chat
+- Poder retomar conversaciones anteriores
+- Ver histórico de mesas de calibración pasadas
+
+### 5. Manejo de contexto largo (futuro)
+**Estado**: Por evaluar
+
+- ¿Qué pasa cuando la conversación es muy larga?
+- ¿Vertex ADK maneja ventanas de contexto automáticamente?
+- ¿Necesitamos summarization manual?
+- Definir estrategia antes de producción
+
+### 6. Comentarios a evaluaciones
+**Estado**: No implementado
+
+- Agregar comentarios a la performance de cada trabajador
+- Desde el chat: "agrega el comentario 'excelente liderazgo' a Paula"
+- Requiere:
+  - **Frontend**: UI para ver/agregar comentarios en cards
+  - **Backend**: Endpoint para guardar comentarios
+  - **Function call**: Tool específico para el agente AI
+
+---
+
+## Flujo de Uso Esperado
+
+```
+1. Manager abre el chat
+2. Pregunta: "¿Quién tiene alertas?"
+3. Chat responde con texto + cards inline de Alvaro y Anibal
+4. Manager hace clic en card de Alvaro → va a mesa de trabajo
+5. Pregunta: "¿Cómo se compara con Paula?"
+6. Chat muestra ComparisonCard inline
+7. Manager hace clic → ComparisonCard va a mesa de trabajo
+8. Pregunta: "Agrega comentario 'necesita coaching' a Alvaro"
+9. Chat confirma y guarda el comentario
+10. Al final, la conversación queda guardada para la reunión
+```
+
+---
+
+## Stack Técnico
+
+- **Frontend**: Next.js 15, React, shadcn/ui, Tailwind
+- **LLM (dev)**: LM Studio + Llama 3 8B
+- **LLM (prod)**: Vertex AI + Gemini (por implementar)
+- **Data (dev)**: Supabase con datos seed
+- **Data (prod)**: Cloud SQL con pgcrypto (por implementar)
+
+---
+
+## Decisiones de Diseño
+
+| Decisión | Razón |
+|----------|-------|
+| Chat-first (Option C) | Validar si managers prefieren conversación vs dashboard tradicional |
+| Cards inline en chat | Contexto visual sin salir de la conversación |
+| Mesa de trabajo separada | Comparar múltiples personas sin perder el chat |
+| Mock fallback | Poder hacer demos sin LLM corriendo |
+| No tracking en mesa | Simplicidad - el chat es la fuente de verdad |

--- a/components/chat/chat-panel.tsx
+++ b/components/chat/chat-panel.tsx
@@ -1,0 +1,613 @@
+"use client";
+
+import { useState, useRef, useEffect } from "react";
+import { Send, Bot, User, Sparkles, Loader2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+import { EmployeeCard, ComparisonCard, EMPLOYEES_DATA } from "./employee-card";
+import { EmployeeDetailPanel } from "./employee-detail-panel";
+
+type CardType = "employee" | "comparison" | null;
+
+interface Message {
+  id: string;
+  role: "user" | "assistant";
+  content: string;
+  timestamp: Date;
+  cardType?: CardType;
+  cardData?: {
+    employeeKey?: string;
+    employeeKeys?: string[]; // For multiple employees
+  };
+}
+
+interface ChatPanelProps {
+  onEmployeeSelect?: (employeeKey: string) => void;
+  onCloseDetail?: () => void;
+  onRemoveFromDetail?: (index: number) => void;
+  onYearChange?: (year: number) => void;
+  selectedEmployees?: string[];
+  contextData?: {
+    managerName?: string;
+    teamSize?: number;
+    selectedYear?: number;
+  };
+}
+
+// Respuestas mock basadas en datos reales de Supabase
+const MOCK_RESPONSES: Record<string, string> = {
+  default:
+    "Entiendo tu pregunta. Déjame buscar esa información en los datos de tu equipo...",
+
+  saludo: `¡Hola! Soy tu asistente de calibración. Puedo ayudarte a:
+
+• **Consultar evaluaciones** de tu equipo
+• **Comparar desempeño** entre colaboradores
+• **Identificar alertas** y casos especiales
+• **Preparar** tu reunión de calibración
+
+¿Qué te gustaría saber sobre tu equipo?`,
+
+  equipo: `Tu equipo tiene **4 colaboradores** este año:
+
+| Nombre | Potencial | Etiqueta | Competencias |
+|--------|-----------|----------|--------------|
+| Paula Roa | 2.5 | Medio (Calibrado) | 3.75 Sobresaliente |
+| Angeles Zuñiga | 3.0 | Medio + | 3.14 Cumple Satisfactorio |
+| Anibal Retamal | 2.5 | Medio (Calibrado) | 2.88 Cumple Parcial |
+| Alvaro Marquez | 2.4 | Bajo (Calibrado) | 3.38 Sobresaliente |
+
+¿Quieres que profundice en algún colaborador?`,
+
+  alertas: `Hay **3 alertas** activas en tu equipo:
+
+🔴 **Alvaro Marquez** - Potencial Bajo (2.4)
+   → Etiqueta: Bajo (Calibrado)
+   → Requiere plan de desarrollo urgente
+
+🟡 **Anibal Retamal** - Competencia baja en cliente
+   → "Nos apasionamos por cliente": 2.5 (Bajo lo esperado)
+   → Necesita coaching en orientación al cliente
+
+🟢 **Angeles Zuñiga** - Competencia baja en futuro
+   → "Cuidamos el futuro": 2.94 (Cumple Parcial)
+   → Oportunidad de mejora
+
+¿Necesitas más detalle sobre alguna alerta?`,
+
+  paula: `**Paula Roa**
+
+📊 **Evaluación 2024:**
+- Potencial: **2.5** (Medio - Calibrado)
+- Jefe Directo: **3.75** (Sobresaliente)
+- Competencias: **3.75** (Sobresaliente)
+
+📈 **Competencias detalladas:**
+| Competencia | Score | Etiqueta |
+|-------------|-------|----------|
+| Somos un solo equipo | 4.0 | Sobresaliente |
+| Nos movemos ágilmente | 3.5 | Sobresaliente |
+| Nos apasionamos por cliente | 3.5 | Sobresaliente |
+| Cuidamos el futuro | 4.0 | Sobresaliente |
+
+✅ **Fortaleza:** Mejor evaluada en competencias del equipo.
+
+¿Quieres compararla con otro colaborador?`,
+
+  comparar: `**Comparación: Paula Roa vs Alvaro Marquez**
+
+| Métrica | Paula Roa | Alvaro Marquez |
+|---------|-----------|----------------|
+| Potencial | 2.5 Medio | 2.4 Bajo |
+| Jefe Directo | 3.75 | 3.13 |
+| Competencias | 3.75 | 3.38 |
+| Somos un equipo | 4.0 | 3.33 |
+| Nos movemos ágil | 3.5 | 3.33 |
+| Cliente | 3.5 | 3.5 |
+| Futuro | 4.0 | 3.33 |
+
+📊 **Análisis:**
+- Paula tiene mejor evaluación general
+- Alvaro necesita plan de desarrollo por potencial bajo
+- Ambos son buenos en orientación al cliente
+
+¿Te ayudo a preparar argumentos para la calibración?`,
+
+  calibracion: `**Preparación para Calibración - Tu Equipo**
+
+📋 **Resumen ejecutivo:**
+- Total: 4 colaboradores
+- Promedio potencial: 2.6
+- Mejor en competencias: Paula Roa (3.75)
+- Requiere atención: Alvaro Marquez (potencial 2.4)
+
+🎯 **Temas clave a discutir:**
+
+1. **Desarrollo prioritario:**
+   - Alvaro Marquez (potencial bajo, necesita plan)
+
+2. **Fortalezas a mantener:**
+   - Paula Roa (excelente en competencias)
+   - Angeles Zuñiga (buen potencial 3.0)
+
+3. **Áreas de mejora:**
+   - Anibal: orientación al cliente (2.5)
+   - Angeles: visión de futuro (2.94)
+
+📝 **Preguntas para el comité:**
+- ¿Plan de desarrollo para Alvaro?
+- ¿Cómo potenciar a Paula para siguiente nivel?
+
+¿Quieres que prepare un one-pager para la reunión?`,
+};
+
+// Llamar a nuestra API route que conecta con LM Studio
+async function getLLMResponse(
+  messages: { role: string; content: string }[],
+): Promise<string> {
+  try {
+    const response = await fetch("/api/chat", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        messages: messages.map((m) => ({
+          role: m.role,
+          content: m.content,
+        })),
+      }),
+    });
+
+    if (!response.ok) {
+      const error = await response.json();
+      throw new Error(error.error || "API error");
+    }
+
+    const data = await response.json();
+    return data.content || "No pude generar una respuesta.";
+  } catch (error) {
+    console.error("Error calling API:", error);
+    // Fallback to mock if API fails
+    const mockResult = getMockResponse(
+      messages[messages.length - 1]?.content || "",
+    );
+    return mockResult.content;
+  }
+}
+
+interface MockResponseResult {
+  content: string;
+  cardType?: CardType;
+  cardData?: {
+    employeeKey?: string;
+    employeeKeys?: string[];
+  };
+}
+
+function getMockResponse(message: string): MockResponseResult {
+  const lowerMessage = message.toLowerCase();
+
+  if (
+    lowerMessage.includes("hola") ||
+    lowerMessage.includes("ayuda") ||
+    lowerMessage.includes("puedes")
+  ) {
+    return { content: MOCK_RESPONSES.saludo };
+  }
+  if (
+    lowerMessage.includes("equipo") ||
+    lowerMessage.includes("team") ||
+    lowerMessage.includes("colaboradores")
+  ) {
+    return { content: MOCK_RESPONSES.equipo };
+  }
+  if (
+    lowerMessage.includes("alerta") ||
+    lowerMessage.includes("flag") ||
+    lowerMessage.includes("problema")
+  ) {
+    return { content: MOCK_RESPONSES.alertas };
+  }
+
+  // Employee cards
+  if (lowerMessage.includes("paula") || lowerMessage.includes("roa")) {
+    return {
+      content: "Aquí está la información de Paula Roa:",
+      cardType: "employee",
+      cardData: { employeeKey: "paula" },
+    };
+  }
+  if (lowerMessage.includes("alvaro") || lowerMessage.includes("marquez")) {
+    return {
+      content: "Aquí está la información de Alvaro Marquez:",
+      cardType: "employee",
+      cardData: { employeeKey: "alvaro" },
+    };
+  }
+  if (lowerMessage.includes("anibal") || lowerMessage.includes("retamal")) {
+    return {
+      content: "Aquí está la información de Anibal Retamal:",
+      cardType: "employee",
+      cardData: { employeeKey: "anibal" },
+    };
+  }
+  if (
+    lowerMessage.includes("angeles") ||
+    lowerMessage.includes("zuñiga") ||
+    lowerMessage.includes("zuniga")
+  ) {
+    return {
+      content: "Aquí está la información de Angeles Zuñiga:",
+      cardType: "employee",
+      cardData: { employeeKey: "angeles" },
+    };
+  }
+
+  // Comparison - detect which employees are mentioned
+  if (
+    lowerMessage.includes("compar") ||
+    lowerMessage.includes("vs") ||
+    lowerMessage.includes("diferencia") ||
+    lowerMessage.includes("todos") ||
+    lowerMessage.includes("equipo")
+  ) {
+    // Detect mentioned employees
+    const mentioned: string[] = [];
+    if (lowerMessage.includes("paula") || lowerMessage.includes("roa"))
+      mentioned.push("paula");
+    if (lowerMessage.includes("alvaro") || lowerMessage.includes("marquez"))
+      mentioned.push("alvaro");
+    if (lowerMessage.includes("anibal") || lowerMessage.includes("retamal"))
+      mentioned.push("anibal");
+    if (
+      lowerMessage.includes("angeles") ||
+      lowerMessage.includes("zuñiga") ||
+      lowerMessage.includes("zuniga")
+    )
+      mentioned.push("angeles");
+
+    // If comparing all or team mentioned, show all
+    if (
+      lowerMessage.includes("todos") ||
+      lowerMessage.includes("equipo") ||
+      mentioned.length === 0
+    ) {
+      return {
+        content: "Aquí tienes a todo tu equipo para comparar:",
+        cardType: "comparison",
+        cardData: { employeeKeys: ["paula", "alvaro", "anibal", "angeles"] },
+      };
+    }
+
+    // If only one mentioned in comparison context, show all
+    if (mentioned.length === 1) {
+      return {
+        content: `Comparación de ${mentioned.length > 1 ? "colaboradores" : "tu equipo"}:`,
+        cardType: "comparison",
+        cardData: { employeeKeys: ["paula", "alvaro", "anibal", "angeles"] },
+      };
+    }
+
+    return {
+      content: `Comparación entre ${mentioned.length} colaboradores:`,
+      cardType: "comparison",
+      cardData: { employeeKeys: mentioned },
+    };
+  }
+  if (
+    lowerMessage.includes("calibra") ||
+    lowerMessage.includes("reuni") ||
+    lowerMessage.includes("preparar")
+  ) {
+    return { content: MOCK_RESPONSES.calibracion };
+  }
+
+  return { content: MOCK_RESPONSES.default };
+}
+
+export function ChatPanel({
+  contextData,
+  selectedEmployees = [],
+  onEmployeeSelect,
+  onCloseDetail,
+  onRemoveFromDetail,
+}: ChatPanelProps) {
+  const [messages, setMessages] = useState<Message[]>([
+    {
+      id: "welcome",
+      role: "assistant",
+      content: MOCK_RESPONSES.saludo,
+      timestamp: new Date(),
+    },
+  ]);
+  const [input, setInput] = useState("");
+  const [isLoading, setIsLoading] = useState(false);
+  const messagesEndRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLTextAreaElement>(null);
+
+  const handleCardClick = (employeeKey: string) => {
+    onEmployeeSelect?.(employeeKey);
+  };
+
+  const scrollToBottom = () => {
+    messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
+  };
+
+  useEffect(() => {
+    scrollToBottom();
+  }, [messages]);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!input.trim() || isLoading) return;
+
+    const userMessage: Message = {
+      id: Date.now().toString(),
+      role: "user",
+      content: input.trim(),
+      timestamp: new Date(),
+    };
+
+    const updatedMessages = [...messages, userMessage];
+    setMessages(updatedMessages);
+    setInput("");
+    setIsLoading(true);
+
+    // Detect if we need to show a card based on user's question
+    const detectCardFromMessage = (
+      msg: string,
+    ): { cardType?: CardType; cardData?: Message["cardData"] } => {
+      const lower = msg.toLowerCase();
+
+      // Employee cards
+      if (lower.includes("paula") || lower.includes("roa")) {
+        return { cardType: "employee", cardData: { employeeKey: "paula" } };
+      }
+      if (lower.includes("alvaro") || lower.includes("marquez")) {
+        return { cardType: "employee", cardData: { employeeKey: "alvaro" } };
+      }
+      if (lower.includes("anibal") || lower.includes("retamal")) {
+        return { cardType: "employee", cardData: { employeeKey: "anibal" } };
+      }
+      if (
+        lower.includes("angeles") ||
+        lower.includes("zuñiga") ||
+        lower.includes("zuniga")
+      ) {
+        return { cardType: "employee", cardData: { employeeKey: "angeles" } };
+      }
+
+      // Comparison
+      if (
+        lower.includes("compar") ||
+        lower.includes("vs") ||
+        lower.includes("diferencia") ||
+        lower.includes("todos") ||
+        lower.includes("equipo")
+      ) {
+        // Detect mentioned employees
+        const mentioned: string[] = [];
+        if (lower.includes("paula") || lower.includes("roa"))
+          mentioned.push("paula");
+        if (lower.includes("alvaro") || lower.includes("marquez"))
+          mentioned.push("alvaro");
+        if (lower.includes("anibal") || lower.includes("retamal"))
+          mentioned.push("anibal");
+        if (
+          lower.includes("angeles") ||
+          lower.includes("zuñiga") ||
+          lower.includes("zuniga")
+        )
+          mentioned.push("angeles");
+
+        // If no specific names or "todos"/"equipo", show all
+        const keys =
+          mentioned.length > 0
+            ? mentioned
+            : ["paula", "alvaro", "anibal", "angeles"];
+        return {
+          cardType: "comparison",
+          cardData: { employeeKeys: keys },
+        };
+      }
+
+      return {};
+    };
+
+    const cardInfo = detectCardFromMessage(userMessage.content);
+
+    // Call LM Studio API
+    const chatHistory = updatedMessages.map((m) => ({
+      role: m.role,
+      content: m.content,
+    }));
+
+    getLLMResponse(chatHistory).then((response) => {
+      const assistantMessage: Message = {
+        id: (Date.now() + 1).toString(),
+        role: "assistant",
+        content: response,
+        timestamp: new Date(),
+        cardType: cardInfo.cardType,
+        cardData: cardInfo.cardData,
+      };
+      setMessages((prev) => [...prev, assistantMessage]);
+      setIsLoading(false);
+    });
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault();
+      handleSubmit(e);
+    }
+  };
+
+  const suggestedQuestions = [
+    "¿Cómo está mi equipo?",
+    "¿Quién tiene alertas?",
+    "Cuéntame sobre Paula Roa",
+    "Prepara mi calibración",
+  ];
+
+  return (
+    <div className="flex flex-col h-full">
+      {/* Main Chat Area */}
+      <div
+        className={`flex flex-col flex-1 min-h-0 transition-all duration-300`}
+      >
+        {/* Header */}
+        <div className="flex items-center gap-3 p-4 border-b bg-gradient-to-r from-primary/5 via-primary/10 to-transparent">
+          <div className="h-10 w-10 rounded-full bg-gradient-to-br from-primary to-primary/70 flex items-center justify-center shadow-lg shadow-primary/20">
+            <Sparkles className="h-5 w-5 text-primary-foreground animate-pulse" />
+          </div>
+          <div>
+            <h2 className="font-semibold bg-gradient-to-r from-foreground to-foreground/70 bg-clip-text">
+              Mesa de Calibración
+            </h2>
+            <p className="text-xs text-muted-foreground">
+              Tu copiloto inteligente para preparar la reunión
+            </p>
+          </div>
+        </div>
+
+        {/* Messages */}
+        <div className="flex-1 overflow-y-auto p-4 space-y-4">
+          {messages.map((message) => (
+            <div
+              key={message.id}
+              className={`flex gap-3 ${message.role === "user" ? "flex-row-reverse" : ""}`}
+            >
+              <div
+                className={`h-8 w-8 rounded-full flex items-center justify-center flex-shrink-0 ${
+                  message.role === "user" ? "bg-primary" : "bg-muted"
+                }`}
+              >
+                {message.role === "user" ? (
+                  <User className="h-4 w-4 text-primary-foreground" />
+                ) : (
+                  <Bot className="h-4 w-4" />
+                )}
+              </div>
+              <div
+                className={`rounded-lg px-4 py-3 max-w-[85%] ${
+                  message.role === "user"
+                    ? "bg-primary text-primary-foreground"
+                    : "bg-muted"
+                }`}
+              >
+                <div className="prose prose-sm dark:prose-invert max-w-none prose-table:text-sm prose-th:px-3 prose-th:py-2 prose-th:bg-muted/50 prose-td:px-3 prose-td:py-2 prose-table:border prose-table:border-border prose-th:border prose-th:border-border prose-td:border prose-td:border-border">
+                  <ReactMarkdown remarkPlugins={[remarkGfm]}>
+                    {message.content}
+                  </ReactMarkdown>
+                </div>
+                {/* Render employee card */}
+                {message.cardType === "employee" &&
+                  message.cardData?.employeeKey && (
+                    <div className="mt-3">
+                      <EmployeeCard
+                        employee={EMPLOYEES_DATA[message.cardData.employeeKey]}
+                        onClick={() =>
+                          handleCardClick(message.cardData!.employeeKey!)
+                        }
+                        isSelected={selectedEmployees.includes(
+                          message.cardData.employeeKey,
+                        )}
+                      />
+                    </div>
+                  )}
+                {/* Render comparison cards - multiple employee cards */}
+                {message.cardType === "comparison" &&
+                  message.cardData?.employeeKeys &&
+                  message.cardData.employeeKeys.length > 0 && (
+                    <div className="mt-3 grid grid-cols-1 sm:grid-cols-2 gap-3">
+                      {message.cardData.employeeKeys.map((key) => (
+                        <EmployeeCard
+                          key={key}
+                          employee={EMPLOYEES_DATA[key]}
+                          onClick={() => handleCardClick(key)}
+                          isSelected={selectedEmployees.includes(key)}
+                          compact
+                        />
+                      ))}
+                    </div>
+                  )}
+              </div>
+            </div>
+          ))}
+
+          {isLoading && (
+            <div className="flex gap-3">
+              <div className="h-8 w-8 rounded-full bg-muted flex items-center justify-center">
+                <Bot className="h-4 w-4" />
+              </div>
+              <div className="bg-muted rounded-lg px-4 py-3">
+                <Loader2 className="h-4 w-4 animate-spin" />
+              </div>
+            </div>
+          )}
+
+          <div ref={messagesEndRef} />
+        </div>
+
+        {/* Suggested questions (only show if few messages) */}
+        {messages.length <= 2 && (
+          <div className="px-4 pb-2">
+            <p className="text-xs text-muted-foreground mb-2">
+              Prueba preguntar:
+            </p>
+            <div className="flex flex-wrap gap-2">
+              {suggestedQuestions.map((q, i) => (
+                <Button
+                  key={i}
+                  variant="outline"
+                  size="sm"
+                  className="text-xs"
+                  onClick={() => setInput(q)}
+                >
+                  {q}
+                </Button>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* Input */}
+        <form onSubmit={handleSubmit} className="p-4 border-t">
+          <div className="flex gap-2">
+            <textarea
+              ref={inputRef}
+              value={input}
+              onChange={(e) => setInput(e.target.value)}
+              onKeyDown={handleKeyDown}
+              placeholder="Escribe tu pregunta..."
+              className="flex-1 resize-none rounded-lg border bg-background px-4 py-3 text-sm focus:outline-none focus:ring-2 focus:ring-primary"
+              rows={1}
+              disabled={isLoading}
+            />
+            <Button
+              type="submit"
+              size="icon"
+              disabled={isLoading || !input.trim()}
+            >
+              <Send className="h-4 w-4" />
+            </Button>
+          </div>
+        </form>
+      </div>
+
+      {/* Bottom Comparison Panel */}
+      {selectedEmployees.length > 0 && (
+        <EmployeeDetailPanel
+          employees={selectedEmployees
+            .filter((key) => EMPLOYEES_DATA[key])
+            .map((key) => EMPLOYEES_DATA[key])}
+          onClose={onCloseDetail || (() => {})}
+          onRemove={onRemoveFromDetail}
+        />
+      )}
+    </div>
+  );
+}

--- a/components/chat/context-sidebar.tsx
+++ b/components/chat/context-sidebar.tsx
@@ -1,0 +1,283 @@
+"use client";
+
+import {
+  Users,
+  AlertTriangle,
+  TrendingUp,
+  Calendar,
+  ChevronRight,
+} from "lucide-react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import type {
+  TeamSummary,
+  EmployeeWithEvaluation,
+} from "@/lib/types/performance.types";
+
+interface ContextSidebarProps {
+  managerName: string;
+  selectedYear: number;
+  teamSummary: TeamSummary;
+  teamMembers: EmployeeWithEvaluation[];
+  onEmployeeClick?: (employeeName: string) => void;
+  selectedEmployees?: string[];
+}
+
+export function ContextSidebar({
+  managerName,
+  selectedYear,
+  teamSummary,
+  teamMembers,
+  onEmployeeClick,
+  selectedEmployees = [],
+}: ContextSidebarProps) {
+  // Helper to check if an employee name matches any selected key
+  const isSelected = (name: string): boolean => {
+    const lower = name.toLowerCase();
+    return selectedEmployees.some((key) => {
+      if (key === "paula" && lower.includes("paula")) return true;
+      if (key === "alvaro" && lower.includes("alvaro")) return true;
+      if (key === "anibal" && lower.includes("anibal")) return true;
+      if (key === "angeles" && lower.includes("angeles")) return true;
+      return false;
+    });
+  };
+  // Alertas basadas en datos reales de Supabase
+  const alerts = [
+    { name: "Alvaro Marquez", type: "Potencial Bajo (2.4)", severity: "high" },
+    { name: "Anibal Retamal", type: "Cliente bajo (2.5)", severity: "medium" },
+    { name: "Angeles Zuñiga", type: "Futuro bajo (2.94)", severity: "low" },
+  ];
+
+  const topPerformers = teamMembers
+    .filter((m) => m.evaluation && (m.evaluation.general_potential ?? 0) >= 4.0)
+    .slice(0, 3);
+
+  return (
+    <div className="flex flex-col gap-4 p-4 h-full overflow-y-auto">
+      {/* Manager Info */}
+      <div className="flex items-center gap-3 pb-4 border-b">
+        <div className="h-12 w-12 rounded-full bg-gradient-to-br from-primary to-primary/60 flex items-center justify-center">
+          <Users className="h-6 w-6 text-primary-foreground" />
+        </div>
+        <div>
+          <p className="text-sm text-muted-foreground">Manager</p>
+          <p className="font-semibold">{managerName}</p>
+        </div>
+      </div>
+
+      {/* Quick Stats */}
+      <Card>
+        <CardHeader className="pb-2">
+          <CardTitle className="text-sm flex items-center gap-2">
+            <Calendar className="h-4 w-4" />
+            Resumen {selectedYear}
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <div className="flex justify-between items-center">
+            <span className="text-sm text-muted-foreground">Equipo</span>
+            <span className="font-semibold">
+              {teamSummary.totalDirectReports} personas
+            </span>
+          </div>
+          <div className="flex justify-between items-center">
+            <span className="text-sm text-muted-foreground">
+              Prom. Potencial
+            </span>
+            <span className="font-semibold">
+              {teamSummary.averagePotential > 0
+                ? teamSummary.averagePotential.toFixed(1)
+                : "N/A"}
+            </span>
+          </div>
+          <div className="flex justify-between items-center">
+            <span className="text-sm text-muted-foreground">
+              Alto Desempeño
+            </span>
+            <span className="font-semibold text-green-600">
+              {teamSummary.highPerformers} (
+              {teamSummary.totalDirectReports > 0
+                ? Math.round(
+                    (teamSummary.highPerformers /
+                      teamSummary.totalDirectReports) *
+                      100,
+                  )
+                : 0}
+              %)
+            </span>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Alerts */}
+      <Card>
+        <CardHeader className="pb-2">
+          <CardTitle className="text-sm flex items-center gap-2">
+            <AlertTriangle className="h-4 w-4 text-orange-500" />
+            Alertas Activas
+            <Badge variant="secondary" className="ml-auto">
+              {alerts.length}
+            </Badge>
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-2">
+          {alerts.map((alert, i) => (
+            <div
+              key={i}
+              className={`flex items-center gap-2 p-2 rounded-lg cursor-pointer transition-colors ${
+                isSelected(alert.name)
+                  ? "bg-primary/10 border border-primary"
+                  : "hover:bg-muted"
+              }`}
+              onClick={() => onEmployeeClick?.(alert.name)}
+            >
+              <div
+                className={`h-2 w-2 rounded-full ${
+                  alert.severity === "high"
+                    ? "bg-red-500"
+                    : alert.severity === "medium"
+                      ? "bg-yellow-500"
+                      : "bg-green-500"
+                }`}
+              />
+              <div className="flex-1 min-w-0">
+                <p className="text-sm font-medium truncate">{alert.name}</p>
+                <p className="text-xs text-muted-foreground">{alert.type}</p>
+              </div>
+              {isSelected(alert.name) ? (
+                <Badge variant="secondary" className="text-xs">
+                  ✓
+                </Badge>
+              ) : (
+                <ChevronRight className="h-4 w-4 text-muted-foreground" />
+              )}
+            </div>
+          ))}
+        </CardContent>
+      </Card>
+
+      {/* Top Performers */}
+      <Card>
+        <CardHeader className="pb-2">
+          <CardTitle className="text-sm flex items-center gap-2">
+            <TrendingUp className="h-4 w-4 text-green-500" />
+            Top Performers
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-2">
+          {topPerformers.length > 0 ? (
+            topPerformers.map((emp, i) => (
+              <div
+                key={i}
+                className="flex items-center gap-2 p-2 rounded-lg hover:bg-muted cursor-pointer transition-colors"
+                onClick={() => onEmployeeClick?.(emp.employee.id)}
+              >
+                <div className="h-8 w-8 rounded-full bg-green-100 dark:bg-green-900 flex items-center justify-center">
+                  <span className="text-xs font-semibold text-green-700 dark:text-green-300">
+                    {emp.employee.first_name[0]}
+                    {emp.employee.last_name[0]}
+                  </span>
+                </div>
+                <div className="flex-1 min-w-0">
+                  <p className="text-sm font-medium truncate">
+                    {emp.employee.first_name} {emp.employee.last_name}
+                  </p>
+                  <p className="text-xs text-muted-foreground">
+                    {emp.evaluation?.general_potential ?? "N/A"} potencial
+                  </p>
+                </div>
+              </div>
+            ))
+          ) : (
+            // Datos reales de Supabase
+            <>
+              <div
+                className={`flex items-center gap-2 p-2 rounded-lg cursor-pointer transition-colors ${
+                  isSelected("Paula Roa")
+                    ? "bg-primary/10 border border-primary"
+                    : "hover:bg-muted"
+                }`}
+                onClick={() => onEmployeeClick?.("Paula Roa")}
+              >
+                <div className="h-8 w-8 rounded-full bg-green-100 dark:bg-green-900 flex items-center justify-center">
+                  <span className="text-xs font-semibold text-green-700 dark:text-green-300">
+                    PR
+                  </span>
+                </div>
+                <div className="flex-1">
+                  <p className="text-sm font-medium">Paula Roa</p>
+                  <p className="text-xs text-muted-foreground">
+                    3.75 competencias
+                  </p>
+                </div>
+                {isSelected("Paula Roa") && (
+                  <Badge variant="secondary" className="text-xs">
+                    ✓
+                  </Badge>
+                )}
+              </div>
+              <div
+                className={`flex items-center gap-2 p-2 rounded-lg cursor-pointer transition-colors ${
+                  isSelected("Angeles Zuñiga")
+                    ? "bg-primary/10 border border-primary"
+                    : "hover:bg-muted"
+                }`}
+                onClick={() => onEmployeeClick?.("Angeles Zuñiga")}
+              >
+                <div className="h-8 w-8 rounded-full bg-green-100 dark:bg-green-900 flex items-center justify-center">
+                  <span className="text-xs font-semibold text-green-700 dark:text-green-300">
+                    AZ
+                  </span>
+                </div>
+                <div className="flex-1">
+                  <p className="text-sm font-medium">Angeles Zuñiga</p>
+                  <p className="text-xs text-muted-foreground">3.0 potencial</p>
+                </div>
+                {isSelected("Angeles Zuñiga") && (
+                  <Badge variant="secondary" className="text-xs">
+                    ✓
+                  </Badge>
+                )}
+              </div>
+              <div
+                className={`flex items-center gap-2 p-2 rounded-lg cursor-pointer transition-colors ${
+                  isSelected("Anibal Retamal")
+                    ? "bg-primary/10 border border-primary"
+                    : "hover:bg-muted"
+                }`}
+                onClick={() => onEmployeeClick?.("Anibal Retamal")}
+              >
+                <div className="h-8 w-8 rounded-full bg-yellow-100 dark:bg-yellow-900 flex items-center justify-center">
+                  <span className="text-xs font-semibold text-yellow-700 dark:text-yellow-300">
+                    AR
+                  </span>
+                </div>
+                <div className="flex-1">
+                  <p className="text-sm font-medium">Anibal Retamal</p>
+                  <p className="text-xs text-muted-foreground">2.5 potencial</p>
+                </div>
+                {isSelected("Anibal Retamal") && (
+                  <Badge variant="secondary" className="text-xs">
+                    ✓
+                  </Badge>
+                )}
+              </div>
+            </>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Quick Tips */}
+      <Card className="bg-primary/5 border-primary/20">
+        <CardContent className="p-4">
+          <p className="text-xs text-muted-foreground mb-2">💡 Tip</p>
+          <p className="text-sm">
+            Pregunta al asistente: "¿Quién debería ser promovido?" para obtener
+            recomendaciones basadas en datos.
+          </p>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/components/chat/employee-card.tsx
+++ b/components/chat/employee-card.tsx
@@ -1,0 +1,373 @@
+"use client";
+
+import { User, TrendingUp, Award, AlertTriangle } from "lucide-react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+
+interface EmployeeData {
+  name: string;
+  potencial: number;
+  potencialLabel: string;
+  competencias: number;
+  competenciasLabel: string;
+  jefeDirecto?: number;
+  jefeDirectoLabel?: string;
+  competenciasDetalle?: {
+    name: string;
+    score: number;
+    label: string;
+  }[];
+  alerta?: string;
+}
+
+interface EmployeeCardProps {
+  employee: EmployeeData;
+  compact?: boolean;
+  onClick?: () => void;
+  isSelected?: boolean;
+}
+
+function getScoreColor(score: number): string {
+  if (score >= 3.3) return "bg-blue-600 text-white";
+  if (score >= 3.0) return "bg-green-600 text-white";
+  if (score >= 2.71) return "bg-yellow-500 text-black";
+  return "bg-orange-500 text-white";
+}
+
+export function EmployeeCard({
+  employee,
+  compact = false,
+  onClick,
+  isSelected,
+}: EmployeeCardProps) {
+  return (
+    <Card
+      className={`w-full max-w-md border-2 transition-all duration-200 ${
+        onClick
+          ? "cursor-pointer hover:border-primary hover:shadow-lg hover:scale-[1.02]"
+          : ""
+      } ${isSelected ? "border-primary ring-2 ring-primary/20 shadow-lg shadow-primary/10" : ""}`}
+      onClick={onClick}
+    >
+      <CardHeader className="pb-3">
+        <CardTitle className="flex items-center gap-3">
+          <div className="h-10 w-10 rounded-full bg-gradient-to-br from-primary to-primary/60 flex items-center justify-center">
+            <User className="h-5 w-5 text-primary-foreground" />
+          </div>
+          <div>
+            <p className="text-lg font-semibold">{employee.name}</p>
+            {employee.alerta && (
+              <div className="flex items-center gap-1 text-orange-500">
+                <AlertTriangle className="h-3 w-3" />
+                <span className="text-xs">{employee.alerta}</span>
+              </div>
+            )}
+          </div>
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {/* Main Metrics */}
+        <div className="grid grid-cols-2 gap-4">
+          <div className="space-y-1">
+            <div className="flex items-center gap-1 text-muted-foreground">
+              <TrendingUp className="h-3 w-3" />
+              <span className="text-xs">Potencial</span>
+            </div>
+            <Badge
+              className={`${getScoreColor(employee.potencial)} border-0 text-lg px-3 py-1`}
+            >
+              {employee.potencial.toFixed(1)}
+            </Badge>
+            <p className="text-xs text-muted-foreground">
+              {employee.potencialLabel}
+            </p>
+          </div>
+          <div className="space-y-1">
+            <div className="flex items-center gap-1 text-muted-foreground">
+              <Award className="h-3 w-3" />
+              <span className="text-xs">Competencias</span>
+            </div>
+            <Badge
+              className={`${getScoreColor(employee.competencias)} border-0 text-lg px-3 py-1`}
+            >
+              {employee.competencias.toFixed(2)}
+            </Badge>
+            <p className="text-xs text-muted-foreground">
+              {employee.competenciasLabel}
+            </p>
+          </div>
+        </div>
+
+        {/* Jefe Directo */}
+        {employee.jefeDirecto && (
+          <div className="pt-2 border-t">
+            <div className="flex items-center justify-between">
+              <span className="text-sm text-muted-foreground">
+                Eval. Jefe Directo
+              </span>
+              <div className="flex items-center gap-2">
+                <Badge
+                  className={`${getScoreColor(employee.jefeDirecto)} border-0`}
+                >
+                  {employee.jefeDirecto.toFixed(2)}
+                </Badge>
+                <span className="text-xs text-muted-foreground">
+                  {employee.jefeDirectoLabel}
+                </span>
+              </div>
+            </div>
+          </div>
+        )}
+
+        {/* Competencias Detalle */}
+        {!compact && employee.competenciasDetalle && (
+          <div className="pt-2 border-t space-y-2">
+            <p className="text-xs font-medium text-muted-foreground">
+              Competencias
+            </p>
+            {employee.competenciasDetalle.map((comp, i) => (
+              <div
+                key={i}
+                className="flex items-center justify-between text-sm"
+              >
+                <span className="truncate flex-1">{comp.name}</span>
+                <div className="flex items-center gap-2">
+                  <Badge
+                    variant="outline"
+                    className={`${getScoreColor(comp.score)} border-0 text-xs`}
+                  >
+                    {comp.score.toFixed(1)}
+                  </Badge>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+interface ComparisonCardProps {
+  employees: EmployeeData[];
+}
+
+export function ComparisonCard({ employees }: ComparisonCardProps) {
+  if (employees.length < 2) return null;
+
+  const metrics = [
+    { label: "Potencial", key: "potencial" as const, icon: "📊" },
+    { label: "Competencias", key: "competencias" as const, icon: "🎯" },
+    { label: "Jefe Directo", key: "jefeDirecto" as const, icon: "👔" },
+  ];
+
+  // Find best value for each metric
+  const findBest = (key: "potencial" | "competencias" | "jefeDirecto") => {
+    const values = employees.map((e) => e[key] ?? 0);
+    const max = Math.max(...values);
+    return employees.map((e) => (e[key] ?? 0) === max && max > 0);
+  };
+
+  const colCount = employees.length + 1;
+  const gridCols =
+    colCount === 3
+      ? "grid-cols-3"
+      : colCount === 4
+        ? "grid-cols-4"
+        : "grid-cols-5";
+
+  return (
+    <Card className="w-full border-2 overflow-hidden">
+      <CardHeader className="pb-2 bg-muted/50">
+        <CardTitle className="text-center text-base">
+          📊 Comparación de {employees.length} colaboradores
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="p-0">
+        {/* Header row with names */}
+        <div className={`grid ${gridCols} border-b bg-muted/30`}>
+          <div className="p-3 text-xs font-medium text-muted-foreground">
+            Métrica
+          </div>
+          {employees.map((emp, i) => (
+            <div key={i} className="p-3 text-center border-l">
+              <p className="font-semibold text-sm">{emp.name.split(" ")[0]}</p>
+              <p className="text-xs text-muted-foreground">
+                {emp.name.split(" ")[1]}
+              </p>
+            </div>
+          ))}
+        </div>
+
+        {/* Metric rows */}
+        {metrics.map((metric) => {
+          const bestIndexes = findBest(metric.key);
+          return (
+            <div
+              key={metric.key}
+              className={`grid ${gridCols} border-b last:border-b-0`}
+            >
+              <div className="p-3 text-xs text-muted-foreground flex items-center gap-1">
+                <span>{metric.icon}</span>
+                <span>{metric.label}</span>
+              </div>
+              {employees.map((emp, i) => {
+                const val = emp[metric.key];
+                if (val === undefined) {
+                  return (
+                    <div
+                      key={i}
+                      className="p-3 text-center border-l text-muted-foreground"
+                    >
+                      -
+                    </div>
+                  );
+                }
+                return (
+                  <div key={i} className="p-3 text-center border-l">
+                    <Badge
+                      className={`${getScoreColor(val)} border-0 ${
+                        bestIndexes[i]
+                          ? "ring-2 ring-green-400 ring-offset-1"
+                          : ""
+                      }`}
+                    >
+                      {val.toFixed(2)}
+                    </Badge>
+                  </div>
+                );
+              })}
+            </div>
+          );
+        })}
+
+        {/* Alerts row */}
+        <div className={`grid ${gridCols} bg-orange-50 dark:bg-orange-950/20`}>
+          <div className="p-3 text-xs text-muted-foreground flex items-center gap-1">
+            <span>⚠️</span>
+            <span>Alertas</span>
+          </div>
+          {employees.map((emp, i) => (
+            <div key={i} className="p-3 text-center border-l">
+              {emp.alerta ? (
+                <span className="text-xs text-orange-600 dark:text-orange-400 font-medium">
+                  {emp.alerta}
+                </span>
+              ) : (
+                <span className="text-xs text-green-600">✓ OK</span>
+              )}
+            </div>
+          ))}
+        </div>
+
+        {/* Labels row */}
+        <div className={`grid ${gridCols} bg-muted/30 border-t`}>
+          <div className="p-3 text-xs text-muted-foreground">Etiqueta</div>
+          {employees.map((emp, i) => (
+            <div key={i} className="p-3 text-center border-l">
+              <span className="text-xs">{emp.potencialLabel}</span>
+            </div>
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+// Mock data for the prototype
+export const EMPLOYEES_DATA: Record<string, EmployeeData> = {
+  paula: {
+    name: "Paula Roa",
+    potencial: 2.5,
+    potencialLabel: "Medio (Calibrado)",
+    competencias: 3.75,
+    competenciasLabel: "Sobresaliente",
+    jefeDirecto: 3.75,
+    jefeDirectoLabel: "Sobresaliente",
+    competenciasDetalle: [
+      { name: "Somos un solo equipo", score: 4.0, label: "Sobresaliente" },
+      { name: "Nos movemos ágilmente", score: 3.5, label: "Sobresaliente" },
+      {
+        name: "Nos apasionamos por cliente",
+        score: 3.5,
+        label: "Sobresaliente",
+      },
+      { name: "Cuidamos el futuro", score: 4.0, label: "Sobresaliente" },
+    ],
+  },
+  alvaro: {
+    name: "Alvaro Marquez",
+    potencial: 2.4,
+    potencialLabel: "Bajo (Calibrado)",
+    competencias: 3.38,
+    competenciasLabel: "Sobresaliente",
+    jefeDirecto: 3.13,
+    jefeDirectoLabel: "Cumple Satisfactorio",
+    alerta: "Potencial Bajo",
+    competenciasDetalle: [
+      { name: "Somos un solo equipo", score: 3.33, label: "Sobresaliente" },
+      { name: "Nos movemos ágilmente", score: 3.33, label: "Sobresaliente" },
+      {
+        name: "Nos apasionamos por cliente",
+        score: 3.5,
+        label: "Sobresaliente",
+      },
+      { name: "Cuidamos el futuro", score: 3.33, label: "Sobresaliente" },
+    ],
+  },
+  anibal: {
+    name: "Anibal Retamal",
+    potencial: 2.5,
+    potencialLabel: "Medio (Calibrado)",
+    competencias: 2.88,
+    competenciasLabel: "Cumple Parcial",
+    jefeDirecto: 2.88,
+    jefeDirectoLabel: "Cumple Parcial",
+    alerta: "Cliente bajo (2.5)",
+    competenciasDetalle: [
+      {
+        name: "Somos un solo equipo",
+        score: 3.0,
+        label: "Cumple Satisfactorio",
+      },
+      {
+        name: "Nos movemos ágilmente",
+        score: 3.0,
+        label: "Cumple Satisfactorio",
+      },
+      {
+        name: "Nos apasionamos por cliente",
+        score: 2.5,
+        label: "Bajo lo esperado",
+      },
+      { name: "Cuidamos el futuro", score: 3.0, label: "Cumple Satisfactorio" },
+    ],
+  },
+  angeles: {
+    name: "Angeles Zuñiga",
+    potencial: 3.0,
+    potencialLabel: "Medio +",
+    competencias: 3.14,
+    competenciasLabel: "Cumple Satisfactorio",
+    jefeDirecto: 3.38,
+    jefeDirectoLabel: "Sobresaliente",
+    competenciasDetalle: [
+      {
+        name: "Somos un solo equipo",
+        score: 3.25,
+        label: "Cumple Satisfactorio",
+      },
+      {
+        name: "Nos movemos ágilmente",
+        score: 3.19,
+        label: "Cumple Satisfactorio",
+      },
+      {
+        name: "Nos apasionamos por cliente",
+        score: 3.19,
+        label: "Cumple Satisfactorio",
+      },
+      { name: "Cuidamos el futuro", score: 2.94, label: "Cumple Parcial" },
+    ],
+  },
+};

--- a/components/chat/employee-detail-panel.tsx
+++ b/components/chat/employee-detail-panel.tsx
@@ -1,0 +1,394 @@
+"use client";
+
+import { useState } from "react";
+import {
+  X,
+  User,
+  TrendingUp,
+  Award,
+  Eye,
+  AlertTriangle,
+  Users,
+  Sparkles,
+} from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent } from "@/components/ui/card";
+
+interface EmployeeData {
+  name: string;
+  potencial: number;
+  potencialLabel: string;
+  competencias: number;
+  competenciasLabel: string;
+  jefeDirecto?: number;
+  jefeDirectoLabel?: string;
+  competenciasDetalle?: {
+    name: string;
+    score: number;
+    label: string;
+  }[];
+  alerta?: string;
+}
+
+interface EmployeeDetailPanelProps {
+  employees: EmployeeData[];
+  onClose: () => void;
+  onRemove?: (index: number) => void;
+  onViewDetail?: (employee: EmployeeData) => void;
+}
+
+function getScoreColor(score: number): string {
+  if (score >= 3.3) return "bg-blue-600 text-white";
+  if (score >= 3.0) return "bg-green-600 text-white";
+  if (score >= 2.71) return "bg-yellow-500 text-black";
+  return "bg-orange-500 text-white";
+}
+
+function CompactComparisonCard({
+  employee,
+  onRemove,
+  onViewDetail,
+}: {
+  employee: EmployeeData;
+  onRemove?: () => void;
+  onViewDetail?: () => void;
+}) {
+  return (
+    <Card className="relative overflow-hidden animate-in fade-in-0 zoom-in-95 duration-300">
+      {/* Remove button */}
+      {onRemove && (
+        <Button
+          variant="ghost"
+          size="icon"
+          className="absolute top-1 right-1 h-6 w-6 opacity-60 hover:opacity-100"
+          onClick={onRemove}
+        >
+          <X className="h-3 w-3" />
+        </Button>
+      )}
+
+      <CardContent className="p-3">
+        {/* Header */}
+        <div className="flex items-center gap-2 mb-3">
+          <div className="h-8 w-8 rounded-full bg-gradient-to-br from-primary to-primary/60 flex items-center justify-center flex-shrink-0">
+            <User className="h-4 w-4 text-primary-foreground" />
+          </div>
+          <div className="min-w-0 flex-1">
+            <p className="font-semibold text-sm truncate">{employee.name}</p>
+            {employee.alerta && (
+              <div className="flex items-center gap-1 text-orange-500">
+                <AlertTriangle className="h-3 w-3" />
+                <span className="text-xs truncate">{employee.alerta}</span>
+              </div>
+            )}
+          </div>
+        </div>
+
+        {/* Metrics Grid */}
+        <div className="grid grid-cols-2 gap-2 mb-3">
+          <div className="text-center p-2 bg-muted/50 rounded">
+            <div className="flex items-center justify-center gap-1 text-muted-foreground mb-1">
+              <TrendingUp className="h-3 w-3" />
+              <span className="text-xs">Potencial</span>
+            </div>
+            <Badge className={`${getScoreColor(employee.potencial)} border-0`}>
+              {employee.potencial.toFixed(1)}
+            </Badge>
+            <p className="text-xs text-muted-foreground mt-1 truncate">
+              {employee.potencialLabel}
+            </p>
+          </div>
+          <div className="text-center p-2 bg-muted/50 rounded">
+            <div className="flex items-center justify-center gap-1 text-muted-foreground mb-1">
+              <Award className="h-3 w-3" />
+              <span className="text-xs">Competencias</span>
+            </div>
+            <Badge
+              className={`${getScoreColor(employee.competencias)} border-0`}
+            >
+              {employee.competencias.toFixed(2)}
+            </Badge>
+            <p className="text-xs text-muted-foreground mt-1 truncate">
+              {employee.competenciasLabel}
+            </p>
+          </div>
+        </div>
+
+        {/* Jefe Directo */}
+        {employee.jefeDirecto && (
+          <div className="flex items-center justify-between text-xs mb-3 px-1">
+            <span className="text-muted-foreground">Jefe Directo</span>
+            <div className="flex items-center gap-1">
+              <Badge
+                className={`${getScoreColor(employee.jefeDirecto)} border-0 text-xs`}
+              >
+                {employee.jefeDirecto.toFixed(2)}
+              </Badge>
+            </div>
+          </div>
+        )}
+
+        {/* Competencias mini list */}
+        {employee.competenciasDetalle && (
+          <div className="space-y-1 mb-3">
+            {employee.competenciasDetalle.slice(0, 4).map((comp, i) => (
+              <div
+                key={i}
+                className="flex items-center justify-between text-xs"
+              >
+                <span className="truncate text-muted-foreground flex-1 mr-2">
+                  {comp.name.split(" ").slice(0, 3).join(" ")}
+                </span>
+                <Badge
+                  variant="outline"
+                  className={`${getScoreColor(comp.score)} border-0 text-xs px-1.5 py-0`}
+                >
+                  {comp.score.toFixed(1)}
+                </Badge>
+              </div>
+            ))}
+          </div>
+        )}
+
+        {/* Ver detalle button */}
+        {onViewDetail && (
+          <Button
+            variant="outline"
+            size="sm"
+            className="w-full text-xs"
+            onClick={onViewDetail}
+          >
+            <Eye className="h-3 w-3 mr-1" />
+            Ver detalle
+          </Button>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+export function EmployeeDetailPanel({
+  employees,
+  onClose,
+  onRemove,
+  onViewDetail,
+}: EmployeeDetailPanelProps) {
+  const [detailEmployee, setDetailEmployee] = useState<EmployeeData | null>(
+    null,
+  );
+
+  if (employees.length === 0) return null;
+
+  // Determine grid columns based on count
+  const getGridClass = (count: number) => {
+    switch (count) {
+      case 1:
+        return "grid-cols-1 max-w-xs mx-auto";
+      case 2:
+        return "grid-cols-2";
+      case 3:
+        return "grid-cols-3";
+      default:
+        return "grid-cols-2 lg:grid-cols-4";
+    }
+  };
+
+  return (
+    <>
+      <div className="border-t bg-gradient-to-t from-muted/50 to-muted/20 p-4 animate-in slide-in-from-bottom-4 duration-300">
+        {/* Header */}
+        <div className="flex items-center justify-between mb-4">
+          <div className="flex items-center gap-2">
+            <div className="h-8 w-8 rounded-lg bg-gradient-to-br from-primary/20 to-primary/5 flex items-center justify-center">
+              {employees.length === 1 ? (
+                <User className="h-4 w-4 text-primary" />
+              ) : (
+                <Users className="h-4 w-4 text-primary" />
+              )}
+            </div>
+            <div>
+              <h3 className="font-semibold text-sm">
+                {employees.length === 1 ? "Mesa de Trabajo" : "Comparación"}
+              </h3>
+              <p className="text-xs text-muted-foreground">
+                {employees.length === 1
+                  ? employees[0].name
+                  : `${employees.length} colaboradores seleccionados`}
+              </p>
+            </div>
+          </div>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={onClose}
+            className="text-muted-foreground hover:text-foreground"
+          >
+            <X className="h-4 w-4" />
+          </Button>
+        </div>
+
+        {/* Cards Grid */}
+        <div className={`grid gap-3 ${getGridClass(employees.length)}`}>
+          {employees.map((emp, index) => (
+            <CompactComparisonCard
+              key={`${emp.name}-${index}`}
+              employee={emp}
+              onRemove={() => onRemove?.(index)}
+              onViewDetail={() => setDetailEmployee(emp)}
+            />
+          ))}
+        </div>
+
+        {employees.length === 1 && (
+          <p className="text-xs text-muted-foreground mt-3 text-center">
+            Haz clic en otras cards del chat o sidebar para comparar
+          </p>
+        )}
+      </div>
+
+      {/* Full Detail Modal */}
+      {detailEmployee && (
+        <FullDetailModal
+          employee={detailEmployee}
+          onClose={() => setDetailEmployee(null)}
+        />
+      )}
+    </>
+  );
+}
+
+// Full detail modal similar to dashboard
+function FullDetailModal({
+  employee,
+  onClose,
+}: {
+  employee: EmployeeData;
+  onClose: () => void;
+}) {
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4 animate-in fade-in-0 duration-200">
+      <div className="bg-background rounded-lg shadow-2xl max-w-2xl w-full max-h-[90vh] overflow-y-auto animate-in zoom-in-95 slide-in-from-bottom-4 duration-300">
+        {/* Header */}
+        <div className="sticky top-0 bg-background border-b p-4 flex items-center justify-between">
+          <div className="flex items-center gap-3">
+            <div className="h-12 w-12 rounded-full bg-gradient-to-br from-primary to-primary/60 flex items-center justify-center">
+              <User className="h-6 w-6 text-primary-foreground" />
+            </div>
+            <div>
+              <h2 className="text-xl font-bold">{employee.name}</h2>
+              {employee.alerta && (
+                <Badge variant="destructive" className="text-xs">
+                  <AlertTriangle className="h-3 w-3 mr-1" />
+                  {employee.alerta}
+                </Badge>
+              )}
+            </div>
+          </div>
+          <Button variant="ghost" size="icon" onClick={onClose}>
+            <X className="h-5 w-5" />
+          </Button>
+        </div>
+
+        <div className="p-4 space-y-4">
+          {/* Main Metrics */}
+          <div className="grid grid-cols-3 gap-4">
+            <Card>
+              <CardContent className="p-4 text-center">
+                <div className="flex items-center justify-center gap-1 text-muted-foreground mb-2">
+                  <TrendingUp className="h-4 w-4" />
+                  <span className="text-sm">Potencial</span>
+                </div>
+                <Badge
+                  className={`${getScoreColor(employee.potencial)} border-0 text-xl px-4 py-1`}
+                >
+                  {employee.potencial.toFixed(1)}
+                </Badge>
+                <p className="text-sm text-muted-foreground mt-2">
+                  {employee.potencialLabel}
+                </p>
+              </CardContent>
+            </Card>
+
+            <Card>
+              <CardContent className="p-4 text-center">
+                <div className="flex items-center justify-center gap-1 text-muted-foreground mb-2">
+                  <Award className="h-4 w-4" />
+                  <span className="text-sm">Competencias</span>
+                </div>
+                <Badge
+                  className={`${getScoreColor(employee.competencias)} border-0 text-xl px-4 py-1`}
+                >
+                  {employee.competencias.toFixed(2)}
+                </Badge>
+                <p className="text-sm text-muted-foreground mt-2">
+                  {employee.competenciasLabel}
+                </p>
+              </CardContent>
+            </Card>
+
+            {employee.jefeDirecto && (
+              <Card>
+                <CardContent className="p-4 text-center">
+                  <div className="flex items-center justify-center gap-1 text-muted-foreground mb-2">
+                    <User className="h-4 w-4" />
+                    <span className="text-sm">Jefe Directo</span>
+                  </div>
+                  <Badge
+                    className={`${getScoreColor(employee.jefeDirecto)} border-0 text-xl px-4 py-1`}
+                  >
+                    {employee.jefeDirecto.toFixed(2)}
+                  </Badge>
+                  <p className="text-sm text-muted-foreground mt-2">
+                    {employee.jefeDirectoLabel}
+                  </p>
+                </CardContent>
+              </Card>
+            )}
+          </div>
+
+          {/* Competencias Detalle */}
+          {employee.competenciasDetalle && (
+            <Card>
+              <CardContent className="p-4">
+                <h3 className="font-semibold mb-3">Desglose de Competencias</h3>
+                <div className="space-y-3">
+                  {employee.competenciasDetalle.map((comp, i) => (
+                    <div key={i} className="flex items-center gap-3">
+                      <div className="flex-1">
+                        <div className="flex items-center justify-between mb-1">
+                          <span className="text-sm font-medium">
+                            {comp.name}
+                          </span>
+                          <Badge
+                            className={`${getScoreColor(comp.score)} border-0`}
+                          >
+                            {comp.score.toFixed(1)}
+                          </Badge>
+                        </div>
+                        <div className="h-2 bg-muted rounded-full overflow-hidden">
+                          <div
+                            className={`h-full ${getScoreColor(comp.score).split(" ")[0]}`}
+                            style={{ width: `${(comp.score / 5) * 100}%` }}
+                          />
+                        </div>
+                        <p className="text-xs text-muted-foreground mt-1">
+                          {comp.label}
+                        </p>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </CardContent>
+            </Card>
+          )}
+        </div>
+
+        {/* Footer */}
+        <div className="sticky bottom-0 bg-background border-t p-4 flex justify-end">
+          <Button onClick={onClose}>Cerrar</Button>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
 Descripción:                                                                                             
  ## Resumen                                                                                               
  Agrega un asistente de chat con IA para ayudar a managers en la preparación de calibraciones.            
                                                                                                           
  ## Cambios                                                                                               
  - Panel de chat con integración a LM Studio (localhost:1234)                                             
  - Sidebar de contexto con resumen del equipo y alertas                                                   
  - Cards de empleados para vista individual y comparaciones                                               
  - Página de chat en `/protected/chat` con layout 70/30                                                   
  - Botón en dashboard para acceder al asistente                                                           
                                                                                                           
  ## Notas                                                                                                 
  - Si LM Studio no está corriendo, el chat usa respuestas mock automáticamente                            
  - No requiere dependencias adicionales       